### PR TITLE
Exclude a few more things from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["multimedia::images", "multimedia::encoding"]
 keywords = ["qoi", "graphics", "image", "encoding"]
 exclude = [
     "assets/*",
+    "doc",
+    "ext",
+    "tests/test_gen.rs",
 ]
 rust-version = "1.61.0"
 


### PR DESCRIPTION
The bundled C library in the ext directory is only used by internal libqoi that isn't published on crates.io, and test_gen.rs tests libqoi (which again isn't published).

The pdf doc isn't used for the build of the published crate either, so exclude this as well.

Pointed out by Fabio Valentini in
https://bugzilla.redhat.com/show_bug.cgi?id=2233787