### PR TITLE
RFE: encoder: add stride & various raw input formats support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ alloc = []
 std = []
 # follows reference encoder implementation precisely, but may be slower
 reference = []
+# allow extra source formats
+extra-source = []
 
 [dependencies]
 bytemuck = "1.22"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT/Apache-2.0"
 authors = ["Ivan Smirnov <rust@ivan.smirnov.ie>"]
 publish = false
 
+[features]
+extra-source = ["qoi/extra-source"]
+
 [dependencies]
 # internal
 libqoi = { path = "../libqoi" }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -297,6 +297,7 @@ impl<'a> Encoder<'a> {
             SourceChannels::Rgb => {
                 encode_impl::<_, 3, 3>(out, self.data, width, height, stride, Pixel::read)
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Bgr => {
                 encode_impl::<_, 3, 3>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgb(c[2], c[1], c[0]);
@@ -305,36 +306,43 @@ impl<'a> Encoder<'a> {
             SourceChannels::Rgba => {
                 encode_impl::<_, 4, 4>(out, self.data, width, height, stride, Pixel::read)
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Argb => {
                 encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgba(c[1], c[2], c[3], c[0]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Rgbx => {
                 encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
                     px.read(&c[..3]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Xrgb => {
                 encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgb(c[1], c[2], c[3]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Bgra => {
                 encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgba(c[2], c[1], c[0], c[3]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Abgr => {
                 encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgba(c[3], c[2], c[1], c[0]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Bgrx => {
                 encode_impl::<_, 3, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgb(c[2], c[1], c[0]);
                 })
             }
+            #[cfg(feature = "extra-source")]
             SourceChannels::Xbgr => {
                 encode_impl::<_, 4, 4>(out, self.data, width, height, stride, |px, c| {
                     px.update_rgb(c[3], c[2], c[1]);

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     InvalidImageDimensions { width: u32, height: u32 },
     /// Image dimensions are inconsistent with image buffer length
     InvalidImageLength { size: usize, width: u32, height: u32 },
+    /// Image stride is inconsistent with image dimension and buffer length
+    InvalidImageStride { size: usize, width: u32, height: u32, stride: usize },
     /// Output buffer is too small to fit encoded/decoded image
     OutputBufferTooSmall { size: usize, required: usize },
     /// Input buffer ended unexpectedly before decoding was finished
@@ -47,6 +49,9 @@ impl Display for Error {
             }
             Self::InvalidImageLength { size, width, height } => {
                 write!(f, "invalid image length: {size} bytes for {width}x{height}")
+            }
+            Self::InvalidImageStride { size, width, height, stride } => {
+                write!(f, "invalid image stride: {stride} for {size} bytes of {width}x{height}")
             }
             Self::OutputBufferTooSmall { size, required } => {
                 write!(f, "output buffer size too small: {size} (required: {required})")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@ pub use crate::decode::{decode_header, decode_to_buf, Decoder};
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use crate::encode::encode_to_vec;
-pub use crate::encode::{encode_max_len, encode_to_buf, Encoder};
+pub use crate::encode::{encode_max_len, encode_to_buf, Encoder, EncoderBuilder};
 
 pub use crate::error::{Error, Result};
 pub use crate::header::Header;
-pub use crate::types::{Channels, ColorSpace};
+pub use crate::types::{Channels, ColorSpace, SourceChannels};

--- a/src/types.rs
+++ b/src/types.rs
@@ -111,3 +111,65 @@ impl TryFrom<u8> for Channels {
         }
     }
 }
+
+/// Pixel format for the source image.
+///
+/// The layout does not depend on the endianness of the system.
+/// The components are stored as bytes in the given order.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum SourceChannels {
+    /// Pixel is R, G and B channels
+    Rgb,
+    /// Pixel is B, G and R channels
+    Bgr,
+    /// Pixel is RGB with an alpha channel
+    Rgba,
+    /// Pixel is an alpha channel and RGB
+    Argb,
+    /// Pixel is RGB with an extra byte
+    Rgbx,
+    /// Pixel is an extra byte and RGB
+    Xrgb,
+    /// Pixel is BGR with an alpha channel
+    Bgra,
+    /// Pixel is an alpha channel and BGR
+    Abgr,
+    /// Pixel is BGR with an extra byte
+    Bgrx,
+    /// Pixel is an extra byte and BGR
+    Xbgr,
+}
+
+impl From<Channels> for SourceChannels {
+    fn from(value: Channels) -> Self {
+        match value {
+            Channels::Rgb => Self::Rgb,
+            Channels::Rgba => Self::Rgba,
+        }
+    }
+}
+
+impl SourceChannels {
+    pub(crate) const fn image_channels(self) -> Channels {
+        match self {
+            Self::Rgb | Self::Bgr | Self::Rgbx | Self::Xrgb | Self::Bgrx | Self::Xbgr => {
+                Channels::Rgb
+            }
+            Self::Rgba | Self::Argb | Self::Bgra | Self::Abgr => Channels::Rgba,
+        }
+    }
+
+    pub(crate) const fn bytes_per_pixel(self) -> usize {
+        match self {
+            Self::Rgb | Self::Bgr => 3,
+            Self::Rgba
+            | Self::Argb
+            | Self::Rgbx
+            | Self::Xrgb
+            | Self::Bgra
+            | Self::Abgr
+            | Self::Bgrx
+            | Self::Xbgr => 4,
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,22 +120,30 @@ impl TryFrom<u8> for Channels {
 pub enum SourceChannels {
     /// Pixel is R, G and B channels
     Rgb,
+    #[cfg(feature = "extra-source")]
     /// Pixel is B, G and R channels
     Bgr,
     /// Pixel is RGB with an alpha channel
     Rgba,
+    #[cfg(feature = "extra-source")]
     /// Pixel is an alpha channel and RGB
     Argb,
+    #[cfg(feature = "extra-source")]
     /// Pixel is RGB with an extra byte
     Rgbx,
+    #[cfg(feature = "extra-source")]
     /// Pixel is an extra byte and RGB
     Xrgb,
+    #[cfg(feature = "extra-source")]
     /// Pixel is BGR with an alpha channel
     Bgra,
+    #[cfg(feature = "extra-source")]
     /// Pixel is an alpha channel and BGR
     Abgr,
+    #[cfg(feature = "extra-source")]
     /// Pixel is BGR with an extra byte
     Bgrx,
+    #[cfg(feature = "extra-source")]
     /// Pixel is an extra byte and BGR
     Xbgr,
 }
@@ -152,18 +160,23 @@ impl From<Channels> for SourceChannels {
 impl SourceChannels {
     pub(crate) const fn image_channels(self) -> Channels {
         match self {
-            Self::Rgb | Self::Bgr | Self::Rgbx | Self::Xrgb | Self::Bgrx | Self::Xbgr => {
-                Channels::Rgb
-            }
-            Self::Rgba | Self::Argb | Self::Bgra | Self::Abgr => Channels::Rgba,
+            Self::Rgb => Channels::Rgb,
+            Self::Rgba => Channels::Rgba,
+            #[cfg(feature = "extra-source")]
+            Self::Bgr | Self::Rgbx | Self::Xrgb | Self::Bgrx | Self::Xbgr => Channels::Rgb,
+            #[cfg(feature = "extra-source")]
+            Self::Argb | Self::Bgra | Self::Abgr => Channels::Rgba,
         }
     }
 
     pub(crate) const fn bytes_per_pixel(self) -> usize {
         match self {
-            Self::Rgb | Self::Bgr => 3,
-            Self::Rgba
-            | Self::Argb
+            Self::Rgb => 3,
+            #[cfg(feature = "extra-source")]
+            Self::Bgr => 3,
+            Self::Rgba => 4,
+            #[cfg(feature = "extra-source")]
+            Self::Argb
             | Self::Rgbx
             | Self::Xrgb
             | Self::Bgra

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -4,7 +4,7 @@ use qoi::{
 };
 
 #[test]
-fn test_new_encoder() {
+fn test_new_decoder() {
     // this used to fail due to `Bytes` not being `pub`
     let arr = [0u8];
     let _ = qoi::Decoder::new(&arr[..]);

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -139,6 +139,7 @@ fn test_new_encoder() -> Result<()> {
         Ok(())
     }
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr3,
         2 * 3,
@@ -149,6 +150,7 @@ fn test_new_encoder() -> Result<()> {
 
     test(&arr4, 2 * 4, SourceChannels::Rgba, Channels::Rgba, &arr4)?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -157,6 +159,7 @@ fn test_new_encoder() -> Result<()> {
         &[2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -165,6 +168,7 @@ fn test_new_encoder() -> Result<()> {
         &[0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -173,6 +177,7 @@ fn test_new_encoder() -> Result<()> {
         &[1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -181,6 +186,7 @@ fn test_new_encoder() -> Result<()> {
         &[2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -189,6 +195,7 @@ fn test_new_encoder() -> Result<()> {
         &[3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,
@@ -197,6 +204,7 @@ fn test_new_encoder() -> Result<()> {
         &[2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12],
     )?;
 
+    #[cfg(feature = "extra-source")]
     test(
         &arr4,
         2 * 4,

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -1,6 +1,6 @@
 use qoi::{
     consts::{QOI_OP_INDEX, QOI_OP_RGB, QOI_OP_RUN},
-    decode_to_vec, Channels, ColorSpace, Header, Result,
+    decode_to_vec, Channels, ColorSpace, Error, Header, Result, SourceChannels,
 };
 
 #[test]
@@ -98,4 +98,112 @@ mod std_tests {
 fn test_big_endian() {
     // so we can see it in the CI logs
     assert_eq!(u16::to_be_bytes(1), [0, 1]);
+}
+
+#[test]
+fn test_new_encoder() -> Result<()> {
+    let arr3 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; // 2 * 2 * 3
+    let arr4 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]; // 2 * 2 * 4
+
+    let enc = qoi::Encoder::new(&arr3, 2, 2)?;
+    assert_eq!(enc.channels(), Channels::Rgb);
+
+    let enc = qoi::Encoder::new(&arr4, 2, 2)?;
+    assert_eq!(enc.channels(), Channels::Rgba);
+
+    assert!(matches!(
+        qoi::Encoder::new(&arr3, 3, 3),
+        Err(Error::InvalidImageLength { size: 12, width: 3, height: 3 })
+    ));
+
+    assert!(matches!(
+        qoi::Encoder::new(&arr3, 1, 1),
+        Err(Error::InvalidImageLength { size: 12, width: 1, height: 1 })
+    ));
+
+    let enc = qoi::EncoderBuilder::new(&arr3, 2, 2).build()?;
+    let mut stream = Vec::new();
+    let _len = enc.encode_to_stream(&mut stream)?;
+    let (_hdr, res) = decode_to_vec(stream)?;
+    assert_eq!(res, &arr3);
+
+    fn test(
+        src: &[u8], stride: usize, sch: SourceChannels, ch: Channels, exp: &[u8],
+    ) -> Result<()> {
+        let enc =
+            qoi::EncoderBuilder::new(src, 2, 2).stride(stride).source_channels(sch).build()?;
+        assert_eq!(enc.channels(), ch);
+        let qoi = enc.encode_to_vec()?;
+        let (_, res) = decode_to_vec(qoi)?;
+        assert_eq!(res, exp, "{} {:?} {:?}", stride, sch, ch);
+        Ok(())
+    }
+
+    test(
+        &arr3,
+        2 * 3,
+        SourceChannels::Bgr,
+        Channels::Rgb,
+        &[2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9],
+    )?;
+
+    test(&arr4, 2 * 4, SourceChannels::Rgba, Channels::Rgba, &arr4)?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Bgra,
+        Channels::Rgba,
+        &[2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Rgbx,
+        Channels::Rgb,
+        &[0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Xrgb,
+        Channels::Rgb,
+        &[1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Bgra,
+        Channels::Rgba,
+        &[2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Abgr,
+        Channels::Rgba,
+        &[3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Bgrx,
+        Channels::Rgb,
+        &[2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12],
+    )?;
+
+    test(
+        &arr4,
+        2 * 4,
+        SourceChannels::Xbgr,
+        Channels::Rgb,
+        &[3, 2, 1, 7, 6, 5, 11, 10, 9, 15, 14, 13],
+    )?;
+
+    Ok(())
 }


### PR DESCRIPTION
The input format is not necessarily RGB or RGBA, and doing a pre-pass conversion can be quite costly (adding about 15-20% of total time from empirical study)

For simplicity reasons, I made sure not to break the existing API.

Those changes don't seem to affect the encoder performance in a significant way.