### PR TITLE
Clean up the manifest, exclude more folders, remove root workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,6 @@ reference = []
 [dependencies]
 bytemuck = "1.22"
 
-[workspace]
-members = ["libqoi", "bench"]
-
 [dev-dependencies]
 # external
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,14 @@ homepage = "https://github.com/aldanor/qoi-rust"
 documentation = "https://docs.rs/qoi"
 categories = ["multimedia::images", "multimedia::encoding"]
 keywords = ["qoi", "graphics", "image", "encoding"]
-exclude = ["assets/*"]
+exclude = [
+    "assets",
+    "doc",
+    "ext",
+    ".github",
+    "tests/test_gen.rs",
+    "tests/test_ref.rs",
+]
 rust-version = "1.67.0"
 
 [features]


### PR DESCRIPTION
Before:
```
    Packaged 34 files, 176.6KiB (75.9KiB compressed)
```

After:
```
    Packaged 22 files, 74.7KiB (20.9KiB compressed)

-rw-r--r--  0 0      0         113  1 Jan  1970 qoi-0.4.1/.cargo_vcs_info.json
-rw-r--r--  0 0      0          72 24 Jul  2006 qoi-0.4.1/.gitignore
-rw-r--r--  0 0      0          82 24 Jul  2006 qoi-0.4.1/.gitmodules
-rw-r--r--  0 0      0        9901  1 Jan  1970 qoi-0.4.1/Cargo.lock
-rw-r--r--  0 0      0        1845  1 Jan  1970 qoi-0.4.1/Cargo.toml
-rw-r--r--  0 0      0        1177 24 Jul  2006 qoi-0.4.1/Cargo.toml.orig
-rw-r--r--  0 0      0       10850 24 Jul  2006 qoi-0.4.1/LICENSE-APACHE
-rw-r--r--  0 0      0        1056 24 Jul  2006 qoi-0.4.1/LICENSE-MIT
-rw-r--r--  0 0      0        2768 24 Jul  2006 qoi-0.4.1/README.md
-rw-r--r--  0 0      0         135 24 Jul  2006 qoi-0.4.1/rustfmt.toml
-rw-r--r--  0 0      0         602 24 Jul  2006 qoi-0.4.1/src/consts.rs
-rw-r--r--  0 0      0       12623 24 Jul  2006 qoi-0.4.1/src/decode.rs
-rw-r--r--  0 0      0        7536 24 Jul  2006 qoi-0.4.1/src/encode.rs
-rw-r--r--  0 0      0        3002 24 Jul  2006 qoi-0.4.1/src/error.rs
-rw-r--r--  0 0      0        3883 24 Jul  2006 qoi-0.4.1/src/header.rs
-rw-r--r--  0 0      0        3345 24 Jul  2006 qoi-0.4.1/src/lib.rs
-rw-r--r--  0 0      0        5184 24 Jul  2006 qoi-0.4.1/src/pixel.rs
-rw-r--r--  0 0      0        2608 24 Jul  2006 qoi-0.4.1/src/types.rs
-rw-r--r--  0 0      0        2193 24 Jul  2006 qoi-0.4.1/src/utils.rs
-rw-r--r--  0 0      0         364 24 Jul  2006 qoi-0.4.1/tests/common.rs
-rw-r--r--  0 0      0        6309 24 Jul  2006 qoi-0.4.1/tests/test_chunks.rs
-rw-r--r--  0 0      0         867 24 Jul  2006 qoi-0.4.1/tests/test_misc.rs
```

- Removed workspace status from root Cargo.toml
- Removed a few tests from the crate package so that the remaining tests can still run

Closes #7 