### PR TITLE
Add with_channels method to Encoder to allow dropping Alpha channel while encoding

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -175,10 +175,10 @@ impl<'a> Encoder<'a> {
     /// Returns a new encoder with modified output channels.
     ///
     /// NOTE: this doesn't change how the provided data is interpreted, it changes
-    /// only how the qoi image gets encoded. This can lead to loss of information
+    /// only how the qoi image gets encoded. This can lead to loss of information.
     #[inline]
-    pub const fn with_channels(mut self, out_channels: Channels) -> Self {
-        self.header = self.header.with_channels(out_channels);
+    pub const fn with_channels(mut self, channels: Channels) -> Self {
+        self.header = self.header.with_channels(channels);
         self
     }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -173,6 +173,9 @@ impl<'a> Encoder<'a> {
     }
 
     /// Returns a new encoder with modified output channels.
+    ///
+    /// NOTE: this doesn't change how the provided data is interpreted, it changes
+    /// only how the qoi image gets encoded. This can lead to loss of information
     #[inline]
     pub const fn with_channels(mut self, out_channels: Channels) -> Self {
         self.header = self.header.with_channels(out_channels);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -193,7 +193,7 @@ impl<'a> Encoder<'a> {
         let (head, tail) = buf.split_at_mut(QOI_HEADER_SIZE); // can't panic
         head.copy_from_slice(&self.header.encode());
         let n_written =
-            encode_impl_all(BytesMut::new(tail), self.data.0, self.data.1, self.header.channels)?;
+            encode_impl_all(BytesMut::new(tail), self.data.0, self.header.channels, self.data.1)?;
         Ok(QOI_HEADER_SIZE + n_written)
     }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -15,14 +15,10 @@ impl<const N: usize> Pixel<N> {
 
     #[inline]
     pub fn read(&mut self, s: &[u8]) {
-        if s.len() == N {
-            let mut i = 0;
-            while i < N {
-                self.0[i] = s[i];
-                i += 1;
-            }
-        } else {
-            unreachable!();
+        match N.cmp(&s.len()) {
+            core::cmp::Ordering::Less => self.0.copy_from_slice(&s[..N]),
+            core::cmp::Ordering::Equal => self.0.copy_from_slice(s),
+            core::cmp::Ordering::Greater => self.0[..s.len()].copy_from_slice(s),
         }
     }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -15,12 +15,10 @@ impl<const N: usize> Pixel<N> {
 
     #[inline]
     pub fn read(&mut self, s: &[u8]) {
-        let len = N.min(s.len());
-
-        let mut i = 0;
-        while i < len {
-            self.0[i] = s[i];
-            i += 1;
+        match N.cmp(&s.len()) {
+            core::cmp::Ordering::Less => self.0.copy_from_slice(&s[..N]),
+            core::cmp::Ordering::Equal => self.0.copy_from_slice(s),
+            core::cmp::Ordering::Greater => self.0[..s.len()].copy_from_slice(s),
         }
     }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -15,10 +15,12 @@ impl<const N: usize> Pixel<N> {
 
     #[inline]
     pub fn read(&mut self, s: &[u8]) {
-        match N.cmp(&s.len()) {
-            core::cmp::Ordering::Less => self.0.copy_from_slice(&s[..N]),
-            core::cmp::Ordering::Equal => self.0.copy_from_slice(s),
-            core::cmp::Ordering::Greater => self.0[..s.len()].copy_from_slice(s),
+        let len = N.min(s.len());
+
+        let mut i = 0;
+        while i < len {
+            self.0[i] = s[i];
+            i += 1;
         }
     }
 


### PR DESCRIPTION
Sometimes I have images with 4 channels, but the alpha channel is always the same. Then I could make the images smaller, by dropping the alpha channel. This allows dropping an existing alpha channel  or adding a new alpha channel without copying to a new buffer.

This doesn't seem to break public api and only adds one new method