### PR TITLE
Fix decoding to larger output buffer (v2)

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -380,6 +380,8 @@ impl<R: Reader> Decoder<R> {
     /// Decodes the image to a pre-allocated buffer and returns the number of bytes written.
     ///
     /// The minimum size of the buffer can be found via [`Decoder::required_buf_len`].
+    /// If the buffer is bigger than the size required, the operation will succeed, writing
+    /// to the leading bytes of the buffer.
     #[inline]
     pub fn decode_to_buf(&mut self, mut buf: impl AsMut<[u8]>) -> Result<usize> {
         let buf = buf.as_mut();
@@ -387,7 +389,11 @@ impl<R: Reader> Decoder<R> {
         if unlikely(buf.len() < size) {
             return Err(Error::OutputBufferTooSmall { size: buf.len(), required: size });
         }
-        self.reader.decode_image(buf, self.channels.as_u8(), self.header.channels.as_u8())?;
+        self.reader.decode_image(
+            &mut buf[..size],
+            self.channels.as_u8(),
+            self.header.channels.as_u8(),
+        )?;
         Ok(size)
     }
 

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -52,6 +52,47 @@ fn test_start_with_qoi_op_run_and_use_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "std")]
+mod std_tests {
+    use qoi::{Channels, ColorSpace, Decoder, Header, Result};
+
+    const ONE_PIXEL_QOI_IMAGE: [u8; 23] = [
+        0x71, 0x6f, 0x69, 0x66, // magic
+        0x00, 0x00, 0x00, 0x01, // width
+        0x00, 0x00, 0x00, 0x01, // height
+        0x04, // number of channels
+        0x00, // colorspace
+        0x55, // QOI_OP_DIFF
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // padding
+    ];
+
+    const ONE_PIXEL_QOI_HEADER: Header =
+        Header { width: 1, height: 1, channels: Channels::Rgba, colorspace: ColorSpace::Srgb };
+
+    #[test]
+    fn test_decode_stream_to_exact_sized_buffer() -> Result<()> {
+        let mut decoder = Decoder::from_stream(&ONE_PIXEL_QOI_IMAGE[..])?;
+        assert_eq!(decoder.header(), &ONE_PIXEL_QOI_HEADER);
+
+        let mut out = vec![0u8; decoder.required_buf_len()];
+        let n_written = decoder.decode_to_buf(&mut out)?;
+        assert_eq!(n_written, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_stream_to_larger_buffer() -> Result<()> {
+        let mut decoder = Decoder::from_stream(&ONE_PIXEL_QOI_IMAGE[..])?;
+        assert_eq!(decoder.header(), &ONE_PIXEL_QOI_HEADER);
+
+        let mut out = vec![0u8; decoder.required_buf_len() + 16];
+        let n_written = decoder.decode_to_buf(&mut out)?;
+        assert_eq!(n_written, 4);
+        assert_eq!(&out[4..], &[0_u8; 16]);
+        Ok(())
+    }
+}
+
 #[cfg(target_endian = "big")]
 #[test]
 fn test_big_endian() {


### PR DESCRIPTION
cc @elmarco - had to rewrite #19 because it has tons of unrelated stuff; updated docstrings as well. Thanks for pointing out - also used your tests.

Closes #18, #19